### PR TITLE
Implement strikethrough and partial transparency for event status

### DIFF
--- a/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEvent.java
+++ b/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEvent.java
@@ -33,6 +33,7 @@ public class CalendarEvent implements WidgetEvent {
     private String location = "";
     private boolean alarmActive;
     private boolean recurring;
+    private int status;
 
     public CalendarEvent(InstanceSettings settings, Context context, int widgetId, boolean allDay) {
         this.settings = settings;
@@ -128,6 +129,10 @@ public class CalendarEvent implements WidgetEvent {
         this.title = notNull(title);
         return this;
     }
+
+    public int getStatus() { return this.status; }
+
+    public void setStatus(int status) { this.status = status; }
 
     public DateTime getEndDate() {
         return endDate;

--- a/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 import android.provider.CalendarContract;
 import android.provider.CalendarContract.Attendees;
 import android.provider.CalendarContract.Instances;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -165,6 +166,7 @@ public class CalendarEventProvider extends EventProvider {
         List<String> columnNames = new ArrayList<>();
         columnNames.add(Instances.CALENDAR_ID);
         columnNames.add(Instances.EVENT_ID);
+        columnNames.add(Instances.STATUS);
         columnNames.add(Instances.TITLE);
         columnNames.add(Instances.BEGIN);
         columnNames.add(Instances.END);
@@ -201,6 +203,7 @@ public class CalendarEventProvider extends EventProvider {
         CalendarEvent event = new CalendarEvent(getSettings(), context, widgetId, allDay);
         event.setEventSource(source);
         event.setEventId(cursor.getInt(cursor.getColumnIndex(Instances.EVENT_ID)));
+        event.setStatus(cursor.getInt(cursor.getColumnIndex(Instances.STATUS)));
         event.setTitle(cursor.getString(cursor.getColumnIndex(Instances.TITLE)));
         event.setStartMillis(cursor.getLong(cursor.getColumnIndex(Instances.BEGIN)));
         event.setEndMillis(cursor.getLong(cursor.getColumnIndex(Instances.END)));
@@ -208,6 +211,7 @@ public class CalendarEventProvider extends EventProvider {
         event.setAlarmActive(cursor.getInt(cursor.getColumnIndex(Instances.HAS_ALARM)) > 0);
         event.setRecurring(cursor.getString(cursor.getColumnIndex(Instances.RRULE)) != null);
         event.setColor(getAsOpaque(cursor.getInt(cursor.getColumnIndex(Instances.DISPLAY_COLOR))));
+        Log.d("feilen", "Status detected as " + event.getStatus() + " for event " + event.getTitle() + ", id " + event.getEventId());
         getColumnIndex(cursor, Instances.CALENDAR_COLOR)
                 .map(ind -> getAsOpaque(cursor.getInt(ind)))
                 .ifPresent(event::setCalendarColor);

--- a/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
@@ -8,7 +8,6 @@ import android.net.Uri;
 import android.provider.CalendarContract;
 import android.provider.CalendarContract.Attendees;
 import android.provider.CalendarContract.Instances;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 

--- a/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
+++ b/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventProvider.java
@@ -210,7 +210,6 @@ public class CalendarEventProvider extends EventProvider {
         event.setAlarmActive(cursor.getInt(cursor.getColumnIndex(Instances.HAS_ALARM)) > 0);
         event.setRecurring(cursor.getString(cursor.getColumnIndex(Instances.RRULE)) != null);
         event.setColor(getAsOpaque(cursor.getInt(cursor.getColumnIndex(Instances.DISPLAY_COLOR))));
-        Log.d("feilen", "Status detected as " + event.getStatus() + " for event " + event.getTitle() + ", id " + event.getEventId());
         getColumnIndex(cursor, Instances.CALENDAR_COLOR)
                 .map(ind -> getAsOpaque(cursor.getInt(ind)))
                 .ifPresent(event::setCalendarColor);

--- a/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventVisualizer.java
+++ b/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventVisualizer.java
@@ -1,7 +1,6 @@
 package org.andstatus.todoagenda.calendar;
 
 import android.content.Intent;
-import android.provider.CalendarContract;
 import android.view.View;
 import android.widget.RemoteViews;
 

--- a/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventVisualizer.java
+++ b/app/src/main/java/org/andstatus/todoagenda/calendar/CalendarEventVisualizer.java
@@ -1,6 +1,7 @@
 package org.andstatus.todoagenda.calendar;
 
 import android.content.Intent;
+import android.provider.CalendarContract;
 import android.view.View;
 import android.widget.RemoteViews;
 

--- a/app/src/main/java/org/andstatus/todoagenda/util/RemoteViewsUtil.java
+++ b/app/src/main/java/org/andstatus/todoagenda/util/RemoteViewsUtil.java
@@ -3,6 +3,7 @@ package org.andstatus.todoagenda.util;
 import android.content.Context;
 import android.content.res.Resources.NotFoundException;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.util.Log;
 import android.util.TypedValue;
 import android.widget.RemoteViews;
@@ -24,6 +25,7 @@ public class RemoteViewsUtil {
     private static final String METHOD_SET_COLOR_FILTER = "setColorFilter";
     private static final String METHOD_SET_WIDTH = "setWidth";
     private static final String METHOD_SET_HEIGHT = "setHeight";
+    private static final String METHOD_SET_PAINT_FLAGS = "setPaintFlags";
 
     private RemoteViewsUtil() {
         // prohibit instantiation
@@ -62,6 +64,21 @@ public class RemoteViewsUtil {
                                     RemoteViews rv, int viewId, int colorAttrId) {
         int color = settings.colors().getTextColor(textColorPref, colorAttrId);
         rv.setTextColor(viewId, color);
+    }
+
+    public static void setTextColorAlpha(InstanceSettings settings, TextColorPref textColorPref,
+                                    RemoteViews rv, int viewId, int colorAttrId, int alpha) {
+        int color = settings.colors().getTextColor(textColorPref, colorAttrId);
+        color = (color & 0xFFFFFF) | (alpha << 24);
+        rv.setTextColor(viewId, color);
+    }
+
+    public static void setTextStrikethrough(RemoteViews rv, int viewID, boolean isStrikethrough) {
+        if (isStrikethrough) {
+            rv.setInt(viewID, METHOD_SET_PAINT_FLAGS, Paint.STRIKE_THRU_TEXT_FLAG | Paint.ANTI_ALIAS_FLAG);
+        } else {
+            rv.setInt(viewID, METHOD_SET_PAINT_FLAGS, Paint.ANTI_ALIAS_FLAG);
+        }
     }
 
     public static void setBackgroundColorFromAttr(Context context, RemoteViews rv, int viewId, int colorAttrId) {

--- a/app/src/main/java/org/andstatus/todoagenda/widget/CalendarEntry.java
+++ b/app/src/main/java/org/andstatus/todoagenda/widget/CalendarEntry.java
@@ -40,6 +40,11 @@ public class CalendarEntry extends WidgetEntry<CalendarEntry> {
         return title;
     }
 
+    @Override
+    public int getStatus() {
+        return event.getStatus();
+    }
+
     public int getColor() {
         return event.getColor();
     }

--- a/app/src/main/java/org/andstatus/todoagenda/widget/WidgetEntry.java
+++ b/app/src/main/java/org/andstatus/todoagenda/widget/WidgetEntry.java
@@ -145,6 +145,10 @@ public abstract class WidgetEntry<T extends WidgetEntry<T>> implements Comparabl
         return "";
     }
 
+    public int getStatus() {
+        return 0;
+    }
+
     String getLocationString() {
         return hideLocation() ? "" : getLocation();
     }

--- a/app/src/main/java/org/andstatus/todoagenda/widget/WidgetEntryVisualizer.java
+++ b/app/src/main/java/org/andstatus/todoagenda/widget/WidgetEntryVisualizer.java
@@ -8,7 +8,6 @@ import android.widget.RemoteViews;
 import androidx.annotation.NonNull;
 
 import org.andstatus.todoagenda.R;
-import org.andstatus.todoagenda.calendar.CalendarEventProvider;
 import org.andstatus.todoagenda.prefs.InstanceSettings;
 import org.andstatus.todoagenda.prefs.colors.TextColorPref;
 import org.andstatus.todoagenda.prefs.dateformat.DateFormatType;
@@ -19,7 +18,6 @@ import org.andstatus.todoagenda.util.RemoteViewsUtil;
 import java.util.List;
 
 import static org.andstatus.todoagenda.util.RemoteViewsUtil.setBackgroundColor;
-import static org.andstatus.todoagenda.util.RemoteViewsUtil.setColorFilter;
 import static org.andstatus.todoagenda.util.RemoteViewsUtil.setMultiline;
 import static org.andstatus.todoagenda.util.RemoteViewsUtil.setTextColor;
 import static org.andstatus.todoagenda.util.RemoteViewsUtil.setTextColorAlpha;


### PR DESCRIPTION
Heya! Been loving this app so far, but I've shared the occasional woe of not quite knowing when an event has been cancelled upstream. This implements a few style changes to indicate when an event's status has changed:

- Confirmed events are solid
- Cancelled events are strikethrough
- Tentative events have 50% transparency

This should take care of https://github.com/andstatus/todoagenda/issues/51, and as an added bonus, make it pretty easy to resolve https://github.com/andstatus/todoagenda/issues/8 in the future if someone has the time for it.

![image](https://user-images.githubusercontent.com/1109288/137833168-6fb184bc-80c1-4a7e-b350-9687bd7d16e1.png)
